### PR TITLE
add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: rust
+cache: cargo
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly
+
+os:
+  - linux
+  - osx
+
+script:
+  - cargo build --verbose --all
+  - cargo test --verbose --all


### PR DESCRIPTION
It's good to use Travis CI to do some basic compile checks. You might need to enable the project in Travis CI dashboard.