### PR TITLE
Count feature

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,6 +1,8 @@
 #[derive(Clone, PartialEq, Debug)]
 pub enum Lexem {
     RawString(String),
+    Select,
+    Count,
     Comma,
     From,
     Where,
@@ -16,6 +18,13 @@ pub enum Lexem {
     DescendingOrder,
     Limit,
     Into,
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub enum Operation {
+    Select,
+    Count,
+    SelectCount,
 }
 
 #[derive(Debug)]
@@ -125,6 +134,8 @@ impl<'a> Lexer<'a> {
             LexingMode::Close => Some(Lexem::Close),
             LexingMode::RawString => {
                 match s.to_lowercase().as_str() {
+                    "select" => Some(Lexem::Select),
+                    "count" => Some(Lexem::Count),
                     "from" => Some(Lexem::From),
                     "where" => Some(Lexem::Where),
                     "or" => Some(Lexem::Or),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -179,7 +179,7 @@ mod tests {
     fn lexems() {
         let mut lexer = Lexer::new("select name, path ,size , fsize from /test depth 2, /test2 archives,/test3 depth 3 archives , /test4 ,'/test5' where name != 123 AND ( size gt 456 or fsize lte 758) or name = 'xxx' order by 1 ,3 desc , path asc limit 50");
 
-        assert_eq!(lexer.next_lexem(), Some(Lexem::RawString(String::from("select"))));
+        assert_eq!(lexer.next_lexem(), Some(Lexem::Select));
         assert_eq!(lexer.next_lexem(), Some(Lexem::RawString(String::from("name"))));
         assert_eq!(lexer.next_lexem(), Some(Lexem::Comma));
         assert_eq!(lexer.next_lexem(), Some(Lexem::RawString(String::from("path"))));
@@ -267,7 +267,7 @@ mod tests {
     fn func_calls() {
         let mut lexer = Lexer::new("COUNT(*), MIN(size), AVG(size), MAX(size) from .");
 
-        assert_eq!(lexer.next_lexem(), Some(Lexem::RawString(String::from("COUNT"))));
+        assert_eq!(lexer.next_lexem(), Some(Lexem::Count));
         assert_eq!(lexer.next_lexem(), Some(Lexem::Open));
         assert_eq!(lexer.next_lexem(), Some(Lexem::RawString(String::from("*"))));
         assert_eq!(lexer.next_lexem(), Some(Lexem::Close));


### PR DESCRIPTION
Added the count feature by modifying the parser. The parser will now first start looking for the "operation mode" which could be `Select`, `Count`, or `SelectCount`. This could perhaps be extended to involve Update or Delete? By default, the parser will resort to the `Select` mode. As for the behavior of the program with respect to the operation mode, the program will do its previous behavior when the `Select` mode is active. If `Count` mode is active, then the output will simply be the count. If `SelectCount` is active, then both the items and the count will be listed. 

Select mode Example: `SELECT \* FROM "/home/name/foobar"`
Count mode Example: `COUNT \* FROM "/home/name/foobar"`
SelectCount mode Example: `SELECT COUNT \* FROM "/home/name/foobar"`