### PR TITLE
early return from min and avg functions for empty dirs

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -346,6 +346,9 @@ pub fn get_aggregate_value(function: &Option<Function>,
                            default_value: &Option<String>) -> String {
     match function {
         Some(Function::Min) => {
+            if raw_output_buffer.len() == 0 {
+                return String::from("0");
+            }
             let mut min = -1;
             for value in raw_output_buffer {
                 if let Some(value) = value.get(&field_value) {
@@ -374,6 +377,9 @@ pub fn get_aggregate_value(function: &Option<Function>,
             return max.to_string();
         },
         Some(Function::Avg) => {
+            if raw_output_buffer.len() == 0 {
+                return String::from("0");
+            }
             let mut sum = 0;
             for value in raw_output_buffer {
                 if let Some(value) = value.get(&field_value) {


### PR DESCRIPTION
add early return from `min` and `avg` functions for empty directories.

should fix #56