### PR TITLE
Fix for EXIF UTF-8 decoding error.

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -488,12 +488,15 @@ pub fn get_exif_metadata(entry: &DirEntry) -> Option<HashMap<String, String>> {
             let mut exif_info = HashMap::new();
 
             for field in reader.fields() {
-                let field_value = match field.value {
-                    exif::Value::Ascii(ref vec) if !vec.is_empty() => std::str::from_utf8(&vec[0]).unwrap().to_string(),
-                    _ => field.value.display_as(field.tag).to_string()
-                };
-
-                exif_info.insert(format!("{}", field.tag), field_value);
+                let field_tag = format!("{}", field.tag);
+                match field.value {
+                    exif::Value::Ascii(ref vec) if !vec.is_empty() => if let Ok(str_value) = std::str::from_utf8(&vec[0]) {
+                        exif_info.insert(field_tag, str_value.to_string());
+                    },
+                    _ =>  {
+                        exif_info.insert(field_tag, field.value.display_as(field.tag).to_string());
+                    }
+                }
             }
 
             return Some(exif_info);


### PR DESCRIPTION
This is a fix for [Issue 80](https://github.com/jhspetersson/fselect/issues/80) where badly formed data in an EXIF field may fail to convert into text via UTF-8.

Although technically all textual data in EXIT is 7-bit ASCII the call to `std::str::from_utf8` is used and the result was unwrapped before any error was checked.

All test cases pass and all images locally that had this error now parse correctly.