### PR TITLE
add CURRENT_USER/CURRENT_UID/CURRENT_GROUP/CURRENT_GID functions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,6 +156,16 @@ Used mostly for formatting results.
 | YEAR | Extract year of the date | `select year(name) from /home/user/Downloads` |
 | DOW or DAYOFWEEK | Returns day of the week (1 - Sunday, 2 - Monday, etc.) | `select name, modified, dow(modified) from /home/user/projects/FizzBuzz` |
 
+#### User functions
+
+These are only available on Unix platforms.
+
+| Function | Meaning |
+| CURRENT_UID  | Current real UID |
+| CURRENT_USER | Current real UID's name |
+| CURRENT_GID  | Current primary GID |
+| CURRENT_GROUP | Current primary GID's name |
+
 #### Xattr functions
 
 Used to check if particular xattr exists, or to get its value.

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,6 +296,11 @@ Functions:
         MONTH                       Returns month of the year
         YEAR                        Returns year of the date
         DOW | DAYOFWEEK             Returns day of the week (1 - Sunday, 2 - Monday, etc.)
+    User:
+        CURRENT_USER                Returns the current username (unix-only)
+        CURRENT_UID                 Returns the current real UID (unix-only)
+        CURRENT_GROUP               Returns the current primary groupname (unix-only)
+        CURRENT_GID                 Returns the current primary GID (unix-only)
     Xattr:
         HAS_XATTR                   Used to check if xattr exists
         XATTR                       Returns value of xattr


### PR DESCRIPTION
These are useful to do things like `fselect 'name, uid WHERE uid <> CURRENT_UID()'`. I know that you can, of course, do something like `fselect "name WHERE uid <> $(id -u)"` but it feels a little cleaner to not have to do shell interpolation.