### PR TITLE
fix build with --no-default-features

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -101,7 +101,9 @@ impl Parser {
                             #[cfg(unix)]
                                 {
                                     fields.push(Expr::field(Field::Mode));
+                                    #[cfg(feature = "users")]
                                     fields.push(Expr::field(Field::User));
+                                    #[cfg(feature = "users")]
                                     fields.push(Expr::field(Field::Group));
                                 }
 


### PR DESCRIPTION
Mistakingly, both Field::User and Field::Group were not behind the `users` feature flag in the parser, causing them to be undefined when trying to build without the default features (`users` enabled).

See resulting build errors prior to changes

```
navi:fselect <master·4ff48>
% cargo build --no-default-features
   Compiling fselect v0.8.3 (/scratch/fselect)
error[E0599]: no variant or associated item named `User` found for enum `field::Field` in the current scope
   --> src/parser.rs:104:68
    |
104 | ...                   fields.push(Expr::field(Field::User));
    |                                                      ^^^^ variant or associated item not found in `Field`
    |
   ::: src/field.rs:9:1
    |
9   | pub enum Field {
    | -------------- variant or associated item `User` not found for this enum

error[E0599]: no variant or associated item named `Group` found for enum `field::Field` in the current scope
   --> src/parser.rs:105:68
    |
105 | ...                   fields.push(Expr::field(Field::Group));
    |                                                      ^^^^^ variant or associated item not found in `Field`
    |
   ::: src/field.rs:9:1
    |
9   | pub enum Field {
    | -------------- variant or associated item `Group` not found for this enum

For more information about this error, try `rustc --explain E0599`.
error: could not compile `fselect` due to 2 previous errors`
```

After applying the provided patch compiles successfully and works as expected.