### PR TITLE
Make duration consistent across file types

### DIFF
--- a/src/util/duration/mp4.rs
+++ b/src/util/duration/mp4.rs
@@ -24,7 +24,7 @@ impl DurationExtractor for Mp4DurationExtractor {
             .and_then(|ref track| {
                 track.tkhd.as_ref().map(|tkhd| {
                     Duration {
-                        length: tkhd.duration as usize
+                        length: (tkhd.duration / 1000) as usize
                     }
                 })
             }))


### PR DESCRIPTION
Before, mp3 and mp4 files returned durations as seconds and milliseconds respectively. This was confusing.

This changes the duration for mp4 files to also be in seconds.
