### PR TITLE
Make license metadata SPDX compliant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://github.com/jhspetersson/fselect/blob/master/docs/usage.
 homepage = "https://github.com/jhspetersson/fselect"
 repository = "https://github.com/jhspetersson/fselect"
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
> Previously multiple licenses could be separated with a /, but that usage is deprecated. 

https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields